### PR TITLE
Add topspace-empty-line-indicator defcustom

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ then be active only when that function returns a non-nil value."
                  (const :tag "never" nil)
                  (function :tag "predicate function")))
 
+(defcustom topspace-empty-line-indicator
+  #'topspace-default-empty-line-indicator
+  "Text that will appear in each empty topspace line above the top text line.
+By default it is \"~\" when `indicate-empty-lines' is non-nil, otherwise \"\".
+Can be set to either a constant string or a function that returns a string."
+  :type '(choice 'string (function :tag "String function")))
+
+(defun topspace-default-empty-line-indicator ()
+  "Return \"~\" with face 'fringe if `indicate-empty-lines` non-nil else \"\"."
+  (if indicate-empty-lines (propertize "~" 'face 'fringe) ""))
+
 (defcustom topspace-mode-line " T"
   "Mode line lighter for Topspace.
 The value of this variable is a mode line template as in

--- a/topspace.el
+++ b/topspace.el
@@ -147,6 +147,17 @@ then be active only when that function returns a non-nil value."
                  (const :tag "never" nil)
                  (function :tag "predicate function")))
 
+(defcustom topspace-empty-line-indicator
+  #'topspace-default-empty-line-indicator
+  "Text that will appear in each empty topspace line above the top text line.
+By default it is \"~\" when `indicate-empty-lines' is non-nil, otherwise \"\".
+Can be set to either a constant string or a function that returns a string."
+  :type '(choice 'string (function :tag "String function")))
+
+(defun topspace-default-empty-line-indicator ()
+  "Return \"~\" with face 'fringe if `indicate-empty-lines` non-nil else \"\"."
+  (if indicate-empty-lines (propertize "~" 'face 'fringe) ""))
+
 (defcustom topspace-mode-line " T"
   "Mode line lighter for Topspace.
 The value of this variable is a mode line template as in
@@ -333,6 +344,18 @@ return unexpected value when END is in column 0. This fixes that issue."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Overlay drawing
 
+(defun topspace--text (height)
+  "Return the topline text that appears in the top overlay with height HEIGHT."
+  (let ((text "")
+        (indicator-line (topspace--eval-choice-p
+                         topspace-empty-line-indicator)))
+    (setq indicator-line (cl-concatenate 'string indicator-line "\n"))
+    (when (> height 0)
+      (dotimes (n height)
+        n ;; remove flycheck warning
+        (setq text (cl-concatenate 'string text indicator-line)))
+      text)))
+
 (defun topspace--put (&optional height)
   "Put/draw top space as an overlay with the target line height HEIGHT."
   (let ((old-height))
@@ -350,8 +373,7 @@ return unexpected value when END is in column 0. This fixes that issue."
       (overlay-put topspace 'topspace--remove-from-window-tag
                    (selected-window))
       (overlay-put topspace 'topspace--remove-from-buffer-tag t)
-      (overlay-put topspace 'before-string (when (> height 0)
-                                             (make-string height ?\n))))
+      (overlay-put topspace 'before-string (topspace--text height)))
     height))
 
 (defun topspace--put-increase-height (total-lines)


### PR DESCRIPTION
Resolves #7 
- By default, "~" will be displayed on each top space line as an empty-line indicator
  if `indicate-empty-lines` is non-nil, and the indicator string's 'face is set to 'fringe
- The empty-line indicator string is customizable through `topspace-empty-line-indicator`
- The string properties and conditions in which it is present are also customizable through
  `topspace-empty-line-indicator` by setting it to a function instead of a constant string.
   Whenever you don't want any indicator present, have the function return "" (an empty string).

-----------------

### Checklist

<!-- Please confirm with `x`: -->

- [x] I have read the topspace [contributing guidelines](https://github.com/trevorpogue/topspace/blob/main/CONTRIBUTING.md)
- [x] My changes follow the [Emacs Lisp conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html) and the [Emacs Lisp Style Guide](https://github.com/bbatsov/emacs-lisp-style-guide)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] The new code is not generating bytecode warnings
- [x] I've updated the readme (if adding/changing user-visible functionality)
- [ ] I have confirmed some of these without doing them

<!-- Thank you! -->
