### PR TITLE
Put topspace-empty-line-indicator inside left fringe

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,33 @@ then be active only when that function returns a non-nil value."
 (defcustom topspace-empty-line-indicator
   #'topspace-default-empty-line-indicator
   "Text that will appear in each empty topspace line above the top text line.
-By default it is \"~\" when `indicate-empty-lines' is non-nil, otherwise \"\".
-Can be set to either a constant string or a function that returns a string."
+Can be set to either a constant string or a function that returns a string.
+
+By default it will show the empty-line bitmap in the left fringe
+if `indicate-empty-lines' is non-nil, otherwise nothing.
+The default bitmap is the one that the `empty-line' logical fringe indicator
+maps to in `fringe-indicator-alist'.
+This is done by adding a 'display property to the string (see
+`topspace-default-empty-line-indicator' for more details).
+
+ You can alternatively show a string in the body of each top space line by
+having `topspace-empty-line-indicator' return a string without the 'display
+property added. If you do this you may be interested in also changing the
+string's face like so: (propertize indicator-string 'face 'fringe)."
   :type '(choice 'string (function :tag "String function")))
 
 (defun topspace-default-empty-line-indicator ()
-  "Return \"~\" with face 'fringe if `indicate-empty-lines` non-nil else \"\"."
-  (if indicate-empty-lines (propertize "~" 'face 'fringe) ""))
+  "Put the empty-line bitmap in fringe if `indicate-empty-lines' is non-nil.
+
+The bitmap used is the one that the `empty-line' logical fringe indicator
+maps to in `fringe-indicator-alist'."
+  (if indicate-empty-lines
+      (let ((bitmap (catch 'tag
+                      (dolist (x fringe-indicator-alist)
+                        (when (eq (car x) 'empty-line)
+                          (throw 'tag (cdr x)))))))
+      (propertize " " 'display (list `left-fringe bitmap `fringe)))
+    ""))
 
 (defcustom topspace-mode-line " T"
   "Mode line lighter for Topspace.

--- a/topspace.el
+++ b/topspace.el
@@ -150,13 +150,33 @@ then be active only when that function returns a non-nil value."
 (defcustom topspace-empty-line-indicator
   #'topspace-default-empty-line-indicator
   "Text that will appear in each empty topspace line above the top text line.
-By default it is \"~\" when `indicate-empty-lines' is non-nil, otherwise \"\".
-Can be set to either a constant string or a function that returns a string."
+Can be set to either a constant string or a function that returns a string.
+
+By default it will show the empty-line bitmap in the left fringe
+if `indicate-empty-lines' is non-nil, otherwise nothing.
+The default bitmap is the one that the `empty-line' logical fringe indicator
+maps to in `fringe-indicator-alist'.
+This is done by adding a 'display property to the string (see
+`topspace-default-empty-line-indicator' for more details).
+
+ You can alternatively show a string in the body of each top space line by
+having `topspace-empty-line-indicator' return a string without the 'display
+property added.  If you do this you may be interested in also changing the
+string's face like so: (propertize indicator-string 'face 'fringe)."
   :type '(choice 'string (function :tag "String function")))
 
 (defun topspace-default-empty-line-indicator ()
-  "Return \"~\" with face 'fringe if `indicate-empty-lines` non-nil else \"\"."
-  (if indicate-empty-lines (propertize "~" 'face 'fringe) ""))
+  "Put the empty-line bitmap in fringe if `indicate-empty-lines' is non-nil.
+
+The bitmap used is the one that the `empty-line' logical fringe indicator
+maps to in `fringe-indicator-alist'."
+  (if indicate-empty-lines
+      (let ((bitmap (catch 'tag
+                      (dolist (x fringe-indicator-alist)
+                        (when (eq (car x) 'empty-line)
+                          (throw 'tag (cdr x)))))))
+      (propertize " " 'display (list `left-fringe bitmap `fringe)))
+    ""))
 
 (defcustom topspace-mode-line " T"
   "Mode line lighter for Topspace.


### PR DESCRIPTION
Fixes #7, enhances #8 
- `topspace-empty-line-indicator` now shows the empty-line bitmap _in the left fringe_ by default
when `indicate-empty-lines' is non-nil

-----------------

### Checklist

<!-- Please confirm with `x`: -->

- [x] I have read the topspace [contributing guidelines](https://github.com/trevorpogue/topspace/blob/main/CONTRIBUTING.md)
- [x] My changes follow the [Emacs Lisp conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html) and the [Emacs Lisp Style Guide](https://github.com/bbatsov/emacs-lisp-style-guide)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] The new code is not generating bytecode warnings
- [x] I've updated the readme (if adding/changing user-visible functionality)
- [ ] I have confirmed some of these without doing them

<!-- Thank you! -->
