### PR TITLE
Add support for `smooth-scrolling` package

### DIFF
--- a/topspace.el
+++ b/topspace.el
@@ -277,6 +277,16 @@ LINE-OFFSET and REDISPLAY are used in the same way as in `recenter'."
                                       (window-start)
                                       (point))))))))
 
+(defun topspace--smooth-scroll-lines-above-point (&rest r)
+  "Add support for `smooth-scroll-mode', ignore R."
+  ;; remove flycheck warnings by using R and checking smooth-scroll functions
+  r
+  (when (and (fboundp 'smooth-scroll-count-lines)
+             (fboundp 'smooth-scroll-line-beginning-position))
+    (+ (topspace--height)
+       (smooth-scroll-count-lines
+        (window-start) (smooth-scroll-line-beginning-position)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Top space line height calculation
 
@@ -580,7 +590,10 @@ Topspace will not be enabled for:
                   #'topspace--filter-args-scroll-down)
       (advice-add #'scroll-up :after #'topspace--after-scroll)
       (advice-add #'scroll-down :after #'topspace--after-scroll)
-      (advice-add #'recenter :after #'topspace--after-recenter))
+      (advice-add #'recenter :after #'topspace--after-recenter)
+      (when (fboundp 'smooth-scroll-lines-above-point)
+        (advice-add #'smooth-scroll-lines-above-point
+                    :override #'topspace--smooth-scroll-lines-above-point)))
     (dolist (window (get-buffer-window-list))
       (with-selected-window window (topspace--draw)))))
 


### PR DESCRIPTION
Resolves #13
- The [`smooth-scrolling`](https://github.com/aspiers/smooth-scrolling) package / `smooth-scrolling-mode` can now be used with `topspce-mode` without unexpected behaviour.

-----------------

### Checklist

<!-- Please confirm with `x`: -->

- [x] I have read the topspace [contributing guidelines](https://github.com/trevorpogue/topspace/blob/main/CONTRIBUTING.md)
- [x] My changes follow the [Emacs Lisp conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html) and the [Emacs Lisp Style Guide](https://github.com/bbatsov/emacs-lisp-style-guide)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] The new code is not generating bytecode warnings
- [x] I've updated the readme (if adding/changing user-visible functionality)
- [ ] I have confirmed some of these without doing them

<!-- Thank you! -->
