### PR TITLE
Add `topspace-height` function for use by external packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,30 @@ To enable `topspace-mode` globally on startup, add the following to your Emacs c
 ```
 # Usage
 ### Just enable and go
-No new keybindings are required, keep using all your previous scrolling & recentering commands, except now you can also scroll above the top lines. 
+No new keybindings are required, keep using all your previous scrolling & recentering commands, except now you can also scroll above the top lines.
 
-# Extra commands
+# Extra functions
 
-### `topspace-recenter-buffer`
-* Add enough top space in the selected window to center small buffers.
+```elisp
+;;;###autoload
+(defun topspace-height ()
+  "Return the top space height in the selected window in number of lines.
+The top space is the empty region in the buffer above the top text line.
+The return value is of type float, and is equivalent to
+the top space pixel height / `default-line-height'."
+...
+
+;;;###autoload
+(defun topspace-recenter-buffer ()
+  "Add enough top space in the selected window to center small buffers.
 Top space will not be added if the number of text lines in the buffer is larger
 than or close to the selected window's height.
-Customize `topspace-center-position` to adjust the centering position.
-Customize `topspace-autocenter-buffers` to run this command automatically
-after first opening buffers and after window sizes change.
+Customize `topspace-center-position' to adjust the centering position.
+Customize `topspace-autocenter-buffers' to run this command automatically
+after first opening buffers and after window sizes change."
+  (interactive)
+...
+```
 
 # Customization
 ```elisp

--- a/topspace.el
+++ b/topspace.el
@@ -555,6 +555,14 @@ ARG defaults to 1."
 ;;; User functions
 
 ;;;###autoload
+(defun topspace-height ()
+  "Return the top space height in the selected window in number of lines.
+The top space is the empty region in the buffer above the top text line.
+The return value is of type float, and is equivalent to
+the top space pixel height / `default-line-height'."
+  (topspace--height))
+
+;;;###autoload
 (defun topspace-recenter-buffer ()
   "Add enough top space in the selected window to center small buffers.
 Top space will not be added if the number of text lines in the buffer is larger


### PR DESCRIPTION
Add public `topspace-height` function for use from external packages to allow them integrate more easily with `topspace`.
- Returns the top space line height in the selected window
- May be useful for example by any package trying to determine the distance in lines between the current line and top of the window (which is no longer guaranteed to be at window-start when using `topspace`).

-----------------

### Checklist

<!-- Please confirm with `x`: -->

- [x] I have read the topspace [contributing guidelines](https://github.com/trevorpogue/topspace/blob/main/CONTRIBUTING.md)
- [x] My changes follow the [Emacs Lisp conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html) and the [Emacs Lisp Style Guide](https://github.com/bbatsov/emacs-lisp-style-guide)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] The new code is not generating bytecode warnings
- [x] I've updated the readme (if adding/changing user-visible functionality)
- [ ] I have confirmed some of these without doing them

<!-- Thank you! -->
