### PR TITLE
Prevent line `1` indicator sometimes displaying too high in `linum-mode`

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,6 +4,7 @@
 (development
  (depends-on "undercover")
  (depends-on "buttercup")
- (depends-on "smooth-scrolling"))
+ (depends-on "smooth-scrolling")
+ (depends-on "linum"))
 
 (package-file "topspace.el")

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -15,6 +15,7 @@
               ))
 
 (require 'smooth-scrolling)
+(require 'linum)
 (require 'topspace)
 
 ;;; test-helper.el ends here

--- a/test/topspace-test.el
+++ b/test/topspace-test.el
@@ -83,11 +83,18 @@
  (describe
   "topspace--after-scroll"
   (it "is needed when first scrolling above the top line"
+      (linum-mode 1)
       (goto-char 1)
       (topspace-set-height 0)
       (scroll-up-line)
       (scroll-down 2)
-      (expect (round (topspace-height)) :to-equal 1)))
+      (linum-mode -1)
+      (goto-char 1)
+      (topspace-set-height 0)
+      (scroll-up-line)
+      (scroll-down 2)
+      (expect (round (topspace-height)) :to-equal 1)
+      ))
 
  (describe
   "topspace--window-configuration-change"

--- a/topspace.el
+++ b/topspace.el
@@ -420,9 +420,9 @@ command is run in the described case above."
                                      1 topspace--window-start-before-scroll)))
         (setq total-lines (abs total-lines))
         (set-window-start (selected-window) 1)
-        (topspace-set-height (- total-lines lines-already-scrolled))))
-    (when (and (bound-and-true-p linum-mode) (fboundp 'linum-update-window))
-      (linum-update-window (selected-window))))))
+        (topspace-set-height (- total-lines lines-already-scrolled)))
+      (when (and (bound-and-true-p linum-mode) (fboundp 'linum-update-window))
+        (linum-update-window (selected-window)))))))
 
 (defun topspace--after-recenter (&optional line-offset redisplay)
   "Recenter near the top of buffers by adding top space appropriately.

--- a/topspace.el
+++ b/topspace.el
@@ -420,7 +420,9 @@ command is run in the described case above."
                                      1 topspace--window-start-before-scroll)))
         (setq total-lines (abs total-lines))
         (set-window-start (selected-window) 1)
-        (topspace-set-height (- total-lines lines-already-scrolled)))))))
+        (topspace-set-height (- total-lines lines-already-scrolled))))
+    (when (and (bound-and-true-p linum-mode) (fboundp 'linum-update-window))
+      (linum-update-window (selected-window))))))
 
 (defun topspace--after-recenter (&optional line-offset redisplay)
   "Recenter near the top of buffers by adding top space appropriately.


### PR DESCRIPTION
<!-- Thank you for improving topspace! -->

<!-- Add here a summary of the changes in your PR with bullet points.
The more detailed, the better. -->

Fixes an issue first mentioned [here](https://github.com/trevorpogue/topspace/issues/17#issuecomment-1198839237) in #17 .

- With `linum-mode` enabled, the line `1` indicator in the left margin would sometimes show too high up, above the actual line 1. The issue would occur when scrolling and `topspace-height` was zero before scrolling but greater than zero after scrolling.  This prevents the issue.

-----------------

### Checklist

<!-- Please confirm by replacing each `[ ]` with `[x]`: -->

- [x] I have read the topspace [contributing guidelines](https://github.com/trevorpogue/topspace/blob/main/CONTRIBUTING.md)
- [x] I have added tests (if possible) to cover my change(s)
- [x] My changes follow the [Emacs Lisp conventions](https://www.gnu.org/software/emacs/manual/html_node/elisp/Tips.html) and the [Emacs Lisp Style Guide](https://github.com/bbatsov/emacs-lisp-style-guide)
- [x] I've used the latest version of [package-lint](https://github.com/purcell/package-lint) to check for packaging issues, and addressed its feedback
- [x] The new code is not generating bytecode warnings
- [x] I've updated the readme (if adding/changing user-visible functionality)
- [ ] I have confirmed some of these without doing them (this box shouldn't be marked)
